### PR TITLE
Fix logger factory for php8 named params compat

### DIFF
--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -118,7 +118,7 @@ class LoggerFactory
         if (!empty($options)) {
             $reflection = new ReflectionClass($params['name']);
 
-            return call_user_func_array(array($reflection, 'newInstance'), $options);
+            return call_user_func_array(array($reflection, 'newInstance'), array_values($options));
         }
 
         $class = $params['name'];


### PR DESCRIPTION
The array-keys passed in `$options` are being interpreted as named parameters for the new object instance and throwing errors